### PR TITLE
Compatibility with RustCrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ An example will suffice to show how it works:
 >>> password = "buildmeupbuttercup"
 >>> salt = 'JqMcHqUcjinFhQKJ'
 >>> print(b.balloon_hash(password, salt))
-99c11d1d483d631783f46c235b81fac88e7d106ff304a5b1e6c7d55450e01583
+2ec8d833db5f88e584ab793950ecfb21657a3816edea8d9e73ea23c13ba2b740
 
 # A slightly more advanced usage
 >>> delta = 5
@@ -41,5 +41,5 @@ An example will suffice to show how it works:
 >>> space_cost = 24
 >>> bs = b.balloon(password, salt, space_cost, time_cost, delta=delta)
 >>> print(bs.hex())
-bf4d8bcd792a22ece165d996a2f1ee3af5ba92a19e79a335d191cd0840f178a6
+69f86890cef40a7ec5f70daff1ce8e2cde233a15bffa785e7efdb5143af51bfb
 ```

--- a/balloon.py
+++ b/balloon.py
@@ -24,7 +24,16 @@ def hash_func(*args) -> bytes:
         str: The hashed string
 
     """
-    t = b''.join(str(arg).encode('utf-8') for arg in args)
+    t = b''
+
+    for arg in args:
+        if type(arg) is int:
+            t += arg.to_bytes(8, "little")
+        elif type(arg) is str:
+            t += arg.encode('utf-8')
+        else:
+            t += arg
+
     return hash_functions[HASH_TYPE](t).digest()
 
 
@@ -75,7 +84,8 @@ def mix(buf, cnt, delta, salt, space_cost, time_cost):
             buf[s] = hash_func(cnt, buf[s - 1], buf[s])
             cnt += 1
             for i in range(delta):
-                other = int(hash_func(cnt, salt, t, s, i).hex(), 16) % space_cost
+                idx_block = hash_func(t, s, i)
+                other = int.from_bytes(hash_func(cnt, salt, idx_block), "little") % space_cost
                 cnt += 1
                 buf[s] = hash_func(cnt, buf[s], buf[other])
                 cnt += 1


### PR DESCRIPTION
Hi!

This PR makes a couple of changes with the goal to make this library compatible with an upcoming Rust implementation in RustCrypto: https://github.com/RustCrypto/password-hashes/pull/232

There are really only two changes required that intend to bring the implementation closer to the research paper/prototype implementation:
1. Values are currently all converted to UTF-8 strings before being hashed, the change improves on that by converting all integers to little-endian 64-bit byte representation and values that are already bytes are passed through instead of converted to strings.
2. The research paper mentions a `ints_to_block` function, but otherwise doesn't go into detail what this is. The prototype implementation uses encryption to create a byte "block" of these values. I have decided to simply hash them with the selected hash. Alternatively it may be valuable to always use SHA-1 here as this part isn't really photographically important and it could avoid any increased cost by "slower" hashes.

I'm open to any suggestions!