### PR TITLE
Only parse 64 bit int

### DIFF
--- a/balloon.py
+++ b/balloon.py
@@ -86,7 +86,7 @@ def mix(
             for i in range(delta):
                 idx_block = hash_func(t, s, i)
                 other = (
-                    int.from_bytes(hash_func(cnt, salt, idx_block), "little")
+                    int.from_bytes(hash_func(cnt, salt, idx_block)[0:8], "little")
                     % space_cost
                 )
                 cnt += 1


### PR DESCRIPTION
I ran into an issue while implementing balloon hashing in javascript using this as a reference.

The issue resolved down to getting different values for `other`, and that was because the python implementation generates a bigint from the entire buffer, rather than reading a 64 bit integer as in the C reference implementation.

Note: This commit breaks all the unit tests, so if those test vectors are known good then the code below is a mistake. But if they're not this may be an issue.