### PR TITLE
Remove need for repeated len(output) checks

### DIFF
--- a/balloon.py
+++ b/balloon.py
@@ -209,13 +209,12 @@ def balloon_m(
                     delta=delta,
                 )
             )
-        for future in concurrent.futures.as_completed(futures):
-            result = future.result()
-
-            if len(output) == 0:
-                output = result
-            else:
-                output = bytes([_a ^ _b for _a, _b in zip(output, result)])
+        completed_futures = concurrent.futures.as_completed(futures)
+        for future in completed_futures:
+            output = future.result()
+            break
+        for future in completed_futures:
+            output = bytes([_a ^ _b for _a, _b in zip(output, future.result())])
 
     return hash_func(password, salt, output)
 

--- a/balloon.py
+++ b/balloon.py
@@ -192,8 +192,6 @@ def balloon_m(
     Returns:
         bytes: A series of bytes, the hash.
     """
-    output = b""
-
     with concurrent.futures.ThreadPoolExecutor() as executor:
         futures = []
 
@@ -210,9 +208,7 @@ def balloon_m(
                 )
             )
         completed_futures = concurrent.futures.as_completed(futures)
-        for future in completed_futures:
-            output = future.result()
-            break
+        output = next(completed_futures).result()
         for future in completed_futures:
             output = bytes([_a ^ _b for _a, _b in zip(output, future.result())])
 


### PR DESCRIPTION
### Changes

- Assign the first `future.result()` to `output` by using a for-loop + break, before running the bitwise zip operation on the remaining `completed_futures`.

### Remarks

This eliminates the need to check `if len(output) == 0:` on every loop iteration. Behaviour remains unchanged even when number of `completed_futures` is 0 or 1.